### PR TITLE
Fix missing distributionManagement in pom

### DIFF
--- a/signalflow-client/pom.xml
+++ b/signalflow-client/pom.xml
@@ -13,7 +13,7 @@
   <groupId>com.signalfx.public</groupId>
   <artifactId>signalflow-client</artifactId>
   <name>SignalFlow Client</name>
-  <version>1.0.0-beta1</version>
+  <version>1.0.0-beta2</version>
   <description>
     SignalFx functionality to support signalflow
   </description>
@@ -100,6 +100,18 @@
     </dependency>
   </dependencies>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <name>Nexus Release Repository</name>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
 
   <build>
     <pluginManagement>

--- a/signalflow-client/src/main/java/com/signalfx/signalflow/client/connection/AbstractHttpReceiverConnection.java
+++ b/signalflow-client/src/main/java/com/signalfx/signalflow/client/connection/AbstractHttpReceiverConnection.java
@@ -27,7 +27,7 @@ public abstract class AbstractHttpReceiverConnection {
     protected static final Logger log = LoggerFactory.getLogger(AbstractHttpReceiverConnection.class);
 
     // Do not modify this line.  It is auto replaced to a version number.
-    public static final String VERSION_NUMBER = "1.0.0-beta1";
+    public static final String VERSION_NUMBER = "1.0.0-beta2";
     public static final String USER_AGENT = "SignalFx-java-client/" + VERSION_NUMBER;
     public static final String DISABLE_COMPRESSION_PROPERTY = "com.signalfx.public.java.disableHttpCompression";
 


### PR DESCRIPTION
Had accidentally removed `distributionManagement` block when migrating project, which is required for release. Bump beta version to be able to create fresh tag for release.