### PR TITLE
Move signing to the right pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,41 +31,6 @@
     </developer>
   </developers>
 
-  <profiles>
-    <profile>
-      <id>release-sign-artifacts</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.13</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.4</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <modules>
     <module>signalflow-client</module>
   </modules>

--- a/signalflow-client/pom.xml
+++ b/signalflow-client/pom.xml
@@ -13,7 +13,7 @@
   <groupId>com.signalfx.public</groupId>
   <artifactId>signalflow-client</artifactId>
   <name>SignalFlow Client</name>
-  <version>1.0.0-beta2</version>
+  <version>1.0.0-beta3</version>
   <description>
     SignalFx functionality to support signalflow
   </description>

--- a/signalflow-client/pom.xml
+++ b/signalflow-client/pom.xml
@@ -113,6 +113,41 @@
     </repository>
   </distributionManagement>
 
+  <profiles>
+    <profile>
+      <id>release-sign-artifacts</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.13</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.4</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/signalflow-client/src/main/java/com/signalfx/signalflow/client/connection/AbstractHttpReceiverConnection.java
+++ b/signalflow-client/src/main/java/com/signalfx/signalflow/client/connection/AbstractHttpReceiverConnection.java
@@ -27,7 +27,7 @@ public abstract class AbstractHttpReceiverConnection {
     protected static final Logger log = LoggerFactory.getLogger(AbstractHttpReceiverConnection.class);
 
     // Do not modify this line.  It is auto replaced to a version number.
-    public static final String VERSION_NUMBER = "1.0.0-beta2";
+    public static final String VERSION_NUMBER = "1.0.0-beta3";
     public static final String USER_AGENT = "SignalFx-java-client/" + VERSION_NUMBER;
     public static final String DISABLE_COMPRESSION_PROPERTY = "com.signalfx.public.java.disableHttpCompression";
 


### PR DESCRIPTION
Signing profiles need to be in the signalflow-client `pom.xml` as the root project is not marked as parent.